### PR TITLE
Bug 1202121 - Update Sony blob archive to v11

### DIFF
--- a/drivers/misc/pn547.c
+++ b/drivers/misc/pn547.c
@@ -524,7 +524,7 @@ static int pn547_probe(struct i2c_client *client,
 	mutex_init(&pn547_dev->read_mutex);
 
 	pn547_dev->pn547_device.minor = MISC_DYNAMIC_MINOR;
-	pn547_dev->pn547_device.name = "pn547";
+	pn547_dev->pn547_device.name = "pn54x";
 	pn547_dev->pn547_device.fops = &pn547_dev_fops;
 
 	ret = misc_register(&pn547_dev->pn547_device);


### PR DESCRIPTION
NFC locations got changed in preparation for Marshmallow. It's easier for us to merge this now than try to cherry-pick all devices repo changes after excluding it.
