### PR TITLE
Bug 1226694 - seagull needs a revert to boot r=gerard-majax

### DIFF
--- a/drivers/input/misc/bma2x2.c
+++ b/drivers/input/misc/bma2x2.c
@@ -1398,8 +1398,6 @@ static const struct interrupt_map_t int_map[] = {
 
 #define MAX_RANGE_MAP	4
 
-static bool skip_pwr_ctl;
-
 struct bma2x2_type_map_t {
 
 	/*! bma2x2 sensor chip id */
@@ -7188,9 +7186,6 @@ static int bma2x2_power_ctl(struct bma2x2_data *data, bool on)
 	int ret = 0;
 	int err = 0;
 
-	if (skip_pwr_ctl)
-		return 0;
-
 	if (!on && data->power_enabled) {
 		ret = regulator_disable(data->vdd);
 		if (ret) {
@@ -7240,10 +7235,11 @@ static int bma2x2_power_init(struct bma2x2_data *data)
 	if (IS_ERR(data->vdd)) {
 		ret = PTR_ERR(data->vdd);
 		dev_err(&data->bma2x2_client->dev,
-			"%s: Regulator get failed vdd ret=%d\n",
-			__func__, ret);
-		skip_pwr_ctl = true;
-	} else if (regulator_count_voltages(data->vdd) > 0) {
+			"Regulator get failed vdd ret=%d\n", ret);
+		return ret;
+	}
+
+	if (regulator_count_voltages(data->vdd) > 0) {
 		ret = regulator_set_voltage(data->vdd,
 				BMA2x2_VDD_MIN_UV,
 				BMA2x2_VDD_MAX_UV);
@@ -7259,10 +7255,11 @@ static int bma2x2_power_init(struct bma2x2_data *data)
 	if (IS_ERR(data->vio)) {
 		ret = PTR_ERR(data->vio);
 		dev_err(&data->bma2x2_client->dev,
-			"%s: Regulator get failed vio ret=%d\n",
-			__func__, ret);
-		skip_pwr_ctl = true;
-	} else if (regulator_count_voltages(data->vio) > 0) {
+			"Regulator get failed vio ret=%d\n", ret);
+		goto reg_vdd_set;
+	}
+
+	if (regulator_count_voltages(data->vio) > 0) {
 		ret = regulator_set_voltage(data->vio,
 				BMA2x2_VIO_MIN_UV,
 				BMA2x2_VIO_MAX_UV);
@@ -7277,6 +7274,7 @@ static int bma2x2_power_init(struct bma2x2_data *data)
 
 reg_vio_put:
 	regulator_put(data->vio);
+reg_vdd_set:
 	if (regulator_count_voltages(data->vdd) > 0)
 		regulator_set_voltage(data->vdd, 0, BMA2x2_VDD_MAX_UV);
 reg_vdd_put:


### PR DESCRIPTION
A change to sensors for tulip (Xperia M4) support, broke boot on
seagull. We would like to support tulip at some point but since
64bit support is just a fantasy right now we'll revert this and
worry abut tulip later.

This reverts commit 5c6f18a609276f049d123e58e794f28cdb1cf99b.
