### PR TITLE
Bug 1090894 - Partial fix for charger LED

### DIFF
--- a/arch/arm/configs/msm8610-perf_defconfig
+++ b/arch/arm/configs/msm8610-perf_defconfig
@@ -457,7 +457,7 @@ CONFIG_USB_AT=y
 #ztebsp zhangjing add mac cdrom,20130506,--
 
 #[ECID:000000] ZTEBSP wanghaifei 201301107 for 8x10 color_led,start
-CONFIG_MODEM_LED=y
+#CONFIG_MODEM_LED=y
 CONFIG_LEDS_MSM_PMIC=y
 #[ECID:000000] ZTEBSP wanghaifei 201301107 for 8x10 color_led,end
 CONFIG_DEVMEM=n

--- a/arch/arm/configs/msm8610_defconfig
+++ b/arch/arm/configs/msm8610_defconfig
@@ -501,6 +501,6 @@ CONFIG_USB_AT=y
 #ztebsp zhangjing add mac cdrom,20130506,--
 
 #[ECID:000000] ZTEBSP wanghaifei 201301107 for 8x10 color_led,start
-CONFIG_MODEM_LED=y
+#CONFIG_MODEM_LED=y
 CONFIG_LEDS_MSM_PMIC=y
 #[ECID:000000] ZTEBSP wanghaifei 201301107 for 8x10 color_led,end

--- a/drivers/leds/leds-msm-pmic.c
+++ b/drivers/leds/leds-msm-pmic.c
@@ -481,16 +481,6 @@ int __devexit msm_led_remove(struct platform_device *pdev)
 
 static int msm_led_suspend(struct device *dev)
 {
-//should always define CONFIG_MODEM_LED, this code only for test current,never used for normal purpose
-#ifndef CONFIG_MODEM_LED 
-	extern void led_set_sleep_time(int time);
-	int i;
-	for (i = 0; i < 2; i++)
-		if ((STATUS_LED->blink_led[i].blink_flag) && (STATUS_LED->blink_led[i].blink_led_flag))
-			led_set_sleep_time(STATUS_LED->blink_led[i].blink_on_time);
-		else if ((STATUS_LED->blink_led[i].blink_flag) && !(STATUS_LED->blink_led[i].blink_led_flag))
-			led_set_sleep_time(STATUS_LED->blink_led[i].blink_off_time);
-#endif
 	STATUS_LED->led_suspend_flag = 1;
 	return 0;
 }


### PR DESCRIPTION
This is a partial fix for the regression which appeared in ZTE's
official B03 firmware release for the Open C FR, preventing the charger
indicator LEDs from working.
The modem firmware in that release does not process requests from the
CPU to change the LEDs state correctly.

This commit works around the issue by having the CPU directly control the
LEDs GPIOs using the gpio-leds driver.

However, this does not bring back full functionality (e.g. blinking),
and will also affect users running a B02 firmware (though there should
be no major visible change).

A better fix now that the kernel source code has been released would be
to disable the MODEM_LED config option and fix the leds-msm-pmic driver.
