### PR TITLE
Bug 1252187 - Disable a warning (-Wno-sizeof-pointer-memaccess) that

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,7 @@ KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common \
 		   -Werror-implicit-function-declaration \
+		   -Wno-sizeof-pointer-memaccess \
 		   -Wno-format-security \
 		   -fno-delete-null-pointer-checks
 KBUILD_AFLAGS_KERNEL :=


### PR DESCRIPTION
breaks compilation with gcc-4.8 Android based toolchain.
