### PR TITLE
Bug 1252658 - Disable some warnings that break kernel compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,8 @@ KBUILD_CPPFLAGS := -D__KERNEL__
 KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common \
 		   -Werror-implicit-function-declaration \
+		   -Wno-sizeof-pointer-memaccess \
+		   -Wno-maybe-uninitialized \
 		   -Wno-format-security \
 		   -fno-delete-null-pointer-checks
 KBUILD_AFLAGS_KERNEL :=


### PR DESCRIPTION
with gcc-4.8 based toolchain
