### PR TITLE
Bug 1195846 - A depricated feature in a Pearl script causes versions of Perl >= 5.21.1 to crash

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
+	$cv = $canned_values{$hz};
+	@val = defined($cv) ? @$cv : compute_values($hz);
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
This happens e.g. when you use the current version of Pearl in Ubuntu 16.04. Other branches that also use a lollipop base may be affected as well.
