### PR TITLE
Bug 1195846 - [foxfone-one-lollipop] A depricated feature in a Pearl script causes versions of Perl >= 5.21.1 to crash

### DIFF
--- a/kernel/timeconst.pl
+++ b/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
+	$cv = $canned_values{$hz};
+	@val = defined($cv) ? @$cv : compute_values($hz);
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
Patch for foxfone-one-lollipop
